### PR TITLE
menu entry to generate menu

### DIFF
--- a/menu.xml
+++ b/menu.xml
@@ -353,7 +353,7 @@
         <action name="Execute">
           <command>gksudo geany /etc/oblogout.conf</command>
         </action>
-      </item>            
+      </item>
       <item label="Choose Wallpaper">
         <action name="Execute">
           <command>nitrogen</command>
@@ -457,6 +457,12 @@
         </action>
       </item>
     </menu>
+    <separator/>
+    <item label="Generate Menu">
+      <action name="Execute">
+        <command>genmenu</command>
+      </action>
+    </item>
     <separator/>
     <item label="ArchLabs Hello">
       <action name="Execute">


### PR DESCRIPTION
added menu entry to call script -- genmenu 
which:
makes a backup of the menu to be used later for switching back
calls obmenu-generator to make a static menu without icons
sends a nice little notification to let you know the outcome

that's it, pretty simple